### PR TITLE
fix: The bottom sheet do not close when the page navigate to other route

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -7,6 +7,12 @@ declare global {
       OWNER: string
       UPDATES_URL: string
       INFURA_ID: string
+      CSB_SCAN: string
+      CSB_XCHAR: string
+      SENTRY_DSN: string
+      SENTRY_ORG: string
+      SENTRY_PROJECT: string
+      SENTRY_AUTH_TOKEN: string
     }
   }
 }

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -17,6 +17,7 @@ interface Props {
   size?: number
   useDefault?: boolean
   isNavigateToUserInfo?: boolean
+  handleBeforeNavigate?: () => void
 }
 
 const isValidUrl = (url) => {
@@ -31,7 +32,7 @@ const isValidUrl = (url) => {
 };
 
 export const Avatar: FC<Props> = (props) => {
-  const { character, size = 45, useDefault = false, isNavigateToUserInfo = true } = props;
+  const { character, size = 45, useDefault = false, isNavigateToUserInfo = true, handleBeforeNavigate } = props;
   const navigation = useRootNavigation();
   const uri = character?.metadata?.content?.avatars?.[0];
   const name = character?.metadata?.content?.name;
@@ -45,6 +46,7 @@ export const Avatar: FC<Props> = (props) => {
     if (!character?.characterId) {
       return;
     }
+    handleBeforeNavigate && handleBeforeNavigate();
     navigation.navigate("UserInfo", { characterId: character?.characterId });
   };
 

--- a/src/components/CommentButton/index.tsx
+++ b/src/components/CommentButton/index.tsx
@@ -231,6 +231,9 @@ export const CommentButton: React.FC<Props> = ({ characterId, noteId, iconSize =
                       }}
                       onComment={comments.refetch}
                       onEdit={comments.refetch}
+                      closeBottomSheet={() => {
+                        bottomSheetRef.current.close();
+                      }}
                     />
                   );
                 }}

--- a/src/components/CommentButton/index.tsx
+++ b/src/components/CommentButton/index.tsx
@@ -231,7 +231,7 @@ export const CommentButton: React.FC<Props> = ({ characterId, noteId, iconSize =
                       }}
                       onComment={comments.refetch}
                       onEdit={comments.refetch}
-                      closeBottomSheet={() => {
+                      onNavigateToUserProfile={() => {
                         bottomSheetRef.current.close();
                       }}
                     />

--- a/src/components/CommentItem/index.tsx
+++ b/src/components/CommentItem/index.tsx
@@ -36,7 +36,7 @@ export interface CommentItemProps extends ListItemProps {
   onPressEdit?: (comment: Comment) => void
   onComment?: () => Promise<any>
   onEdit?: () => Promise<any>
-  closeBottomSheet?: () => void
+  onNavigateToUserProfile?: () => void
 }
 
 export type Comment = NoteEntity & {
@@ -56,7 +56,7 @@ export const CommentItem: React.FC<CommentItemProps> = (props) => {
     onPressEdit: _onPressEdit,
     onComment,
     onEdit,
-    closeBottomSheet,
+    onNavigateToUserProfile,
     ...restProps
   } = props;
   const date = useDate();
@@ -135,7 +135,7 @@ export const CommentItem: React.FC<CommentItemProps> = (props) => {
   return (
     <>
       <XStack marginBottom="$2" gap="$3" {...restProps}>
-        <Avatar useDefault size={isSubComment ? 36 : 40} character={comment?.character} handleBeforeNavigate={closeBottomSheet} />
+        <Avatar useDefault size={isSubComment ? 36 : 40} character={comment?.character} handleBeforeNavigate={onNavigateToUserProfile} />
         <YStack flex={1}>
           <YStack flex={1}>
             <XStack alignItems="center" marginBottom="$1">

--- a/src/components/CommentItem/index.tsx
+++ b/src/components/CommentItem/index.tsx
@@ -36,6 +36,7 @@ export interface CommentItemProps extends ListItemProps {
   onPressEdit?: (comment: Comment) => void
   onComment?: () => Promise<any>
   onEdit?: () => Promise<any>
+  closeBottomSheet?: () => void
 }
 
 export type Comment = NoteEntity & {
@@ -55,6 +56,7 @@ export const CommentItem: React.FC<CommentItemProps> = (props) => {
     onPressEdit: _onPressEdit,
     onComment,
     onEdit,
+    closeBottomSheet,
     ...restProps
   } = props;
   const date = useDate();
@@ -133,7 +135,7 @@ export const CommentItem: React.FC<CommentItemProps> = (props) => {
   return (
     <>
       <XStack marginBottom="$2" gap="$3" {...restProps}>
-        <Avatar useDefault size={isSubComment ? 36 : 40} character={comment?.character} />
+        <Avatar useDefault size={isSubComment ? 36 : 40} character={comment?.character} handleBeforeNavigate={closeBottomSheet} />
         <YStack flex={1}>
           <YStack flex={1}>
             <XStack alignItems="center" marginBottom="$1">


### PR DESCRIPTION
The bottom sheet do not close when the page navigate to other route

https://github.com/Crossbell-Box/xLog-mobile/assets/18499412/8daecb06-2f82-4391-93ed-47593aa66ed5

I'm not sure if this is a feature, but if it's a bug, I have already fixed it in this pull request.

However, the imperfection is that navigate does not provide a callback after successful navigation, so it cannot control the timing of the closure well.

![Jun-30-2023 03-16-23](https://github.com/Crossbell-Box/xLog-mobile/assets/18499412/c78e7e9e-2417-4755-8dd7-92b418c20a59.gif)


